### PR TITLE
Support testing mode.

### DIFF
--- a/iptables/flush.sls
+++ b/iptables/flush.sls
@@ -1,7 +1,7 @@
   {% set firewall = salt['pillar.get']('firewall', {}) %}
 
-  # if flush = true, set policy to ACCEPT and flush all 
-  {% set flush = firewall.get('flush', False ) %}
+  # If flush = true, set policy to ACCEPT and flush all.
+  {% set flush = firewall.get('flush', False) %}
 
   {%- if flush %}
   # IPv6 is missing!
@@ -30,4 +30,27 @@
             - iptables: iptables_input_policy_accept
             - iptables: iptables_output_policy_accept
             - iptables: iptables_forward_policy_accept
+  {%- endif %}
+
+  # If testing_mode.enabled = true, it will flush iptables after x seconds.
+  {% set testing_mode = firewall.get('testing_mode') %}
+  {% set testing_mode_enabled = testing_mode.get('enabled', True) %}
+  {% set testing_mode_timer = testing_mode.get('flush_after', 60)|int %}
+
+  {%- if testing_mode_enabled %}
+      iptables_flush_testing_mode:
+        schedule.present:
+          - function: state.sls_id
+          - job_args:
+            - iptables_flush
+            - iptables.flush
+          # This is a workaround to mimic "now + x seconds", since Salt schedule just supports ISO8601 time format.
+          - once: "{{ (None|strftime("%s")|int + testing_mode_timer)|strftime("%Y-%m-%dT%H:%M:%S") }}"
+          - once_fmt: "%Y-%m-%dT%H:%M:%S"
+          - persist: False
+          - order: last
+  {%- else %}
+      delete_iptables_flush_testing_mode_job:
+        schedule.absent:
+          - name: iptables_flush_testing_mode
   {%- endif %}

--- a/iptables/flush.sls
+++ b/iptables/flush.sls
@@ -45,6 +45,7 @@
             - iptables_flush
             - iptables.flush
           # This is a workaround to mimic "now + x seconds", since Salt schedule just supports ISO8601 time format.
+          # It generates "now" based on Unix Time, then it add x number of seconds, finally it converts that to ISO8601 time.
           - once: "{{ (None|strftime("%s")|int + testing_mode_timer)|strftime("%Y-%m-%dT%H:%M:%S") }}"
           - once_fmt: "%Y-%m-%dT%H:%M:%S"
           - persist: False

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,11 @@ firewall:
   flush: False
   debug: True
 
+  # Flush rules after x seconds.
+  testing_mode:
+      enabled: True
+      flush_after: 30
+
   services:
     ssh:
       comment: "Allow SSH access"


### PR DESCRIPTION
I think having "testing mode" with iptables is an essential thing, even in an environment that could totally rebuild from scratch.

The testing mode flushes all rules after x seconds if it was enabled.

And I did make sure avoid any low level tools like `at command` or even SaltStack `at module` although SaltStack `schedule` doesn't support that style "now + x seconds".